### PR TITLE
Fix: Handle Web NFC unavailability and improve error messages

### DIFF
--- a/src/components/HelloWorld.vue
+++ b/src/components/HelloWorld.vue
@@ -1,4 +1,12 @@
 <script setup lang="ts">
+// IMPORTANT: Web NFC API Requirements
+// 1. HTTPS: The page must be served over HTTPS (localhost is usually an exception for development).
+// 2. Compatible Browser: Use a browser that supports Web NFC (e.g., Chrome on Android).
+// 3. User Gesture: NFC operations must be initiated by a user gesture (e.g., a button click).
+// 4. Permissions: The browser may ask for user permission to use NFC.
+// 5. Experimental Flags (Sometimes): Depending on the browser version, you might need to enable
+//    experimental web platform features or specific flags (e.g., in chrome://flags).
+
 import { ref } from "vue";
 
 defineProps<{ msg: string }>();
@@ -7,12 +15,19 @@ const count = ref(0);
 const message = ref("");
 
 const readTag = async () => {
+  if (!("NDEFReader" in window)) {
+    message.value =
+      "Web NFC is not available. Please use a compatible browser (e.g., Chrome on Android) and ensure it's enabled.";
+    return;
+  }
   try {
+    // TODO: Fix: Property 'NDEFReader' does not exist on type 'Window & typeof globalThis'.
+    // @ts-ignore
     const ndef = new NDEFReader();
     await ndef.scan();
     message.value = "Bring a tag closer to read.";
 
-    ndef.onreading = (event) => {
+    ndef.onreading = (event: any) => {
       const decoder = new TextDecoder();
       for (const record of event.message.records) {
         message.value = `Record type: ${record.recordType}\n`;
@@ -21,19 +36,26 @@ const readTag = async () => {
       }
     };
   } catch (error) {
-    message.value = `Error: ${error}`;
+    message.value = `Error reading tag: ${error}`;
   }
 };
 
 const writeTag = async () => {
+  if (!("NDEFReader" in window)) {
+    message.value =
+      "Web NFC is not available. Please use a compatible browser (e.g., Chrome on Android) and ensure it's enabled.";
+    return;
+  }
   try {
+    // TODO: Fix: Property 'NDEFReader' does not exist on type 'Window & typeof globalThis'.
+    // @ts-ignore
     const ndef = new NDEFReader();
     await ndef.write({
       records: [{ recordType: "text", data: "hello world" }],
     });
     message.value = 'Wrote "hello world" to tag.';
   } catch (error) {
-    message.value = `Error: ${error}`;
+    message.value = `Error writing to tag: ${error}`;
   }
 };
 </script>


### PR DESCRIPTION
- Added a check for `NDEFReader` in `window` before attempting to use it in `HelloWorld.vue`.
- Displays a user-friendly message if Web NFC is not supported/enabled.
- Improved error messages in `readTag` and `writeTag` for better clarity.
- Added comments to guide users on Web NFC environment setup (HTTPS, compatible browser, etc.).
- Temporarily used `@ts-ignore` for NDEFReader type issues, with a TODO for a proper fix.