### PR TITLE
feat: Clear success message after NFC tag read

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -91,6 +91,11 @@ const readTag = async () => {
       }
       if (!sinDataFound) {
         message.value += "No Shadowrun SIN data found on this tag.";
+      } else {
+        // Clear the message after a delay if SIN data was found
+        setTimeout(() => {
+          message.value = "";
+        }, 5000); // Clear after 5 seconds
       }
     };
 


### PR DESCRIPTION
Automatically clears the on-screen message 5 seconds after successfully reading and displaying SIN data from an NFC tag. Messages for errors or tags without SIN data will persist.