### PR TITLE
Refactor: Simplify IdCard.vue tab rendering logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,6 +7,7 @@ import {
   type ShadowrunNationalityType,
 } from "./components/shadowrun-flags";
 import type { ShadowrunMetatypeType } from "./components/shadowrun-metatypes"; // Import Metatype type
+import type { SinQuality } from "./components/sin-quality"; // Import SinQuality type
 
 // Define SINData interface
 interface SinData {
@@ -15,6 +16,7 @@ interface SinData {
   nationality: ShadowrunNationalityType;
   metatype: ShadowrunMetatypeType;
   imageUrl: string;
+  sinQuality: SinQuality; // Added SIN Quality
 }
 
 const message = ref("");
@@ -29,6 +31,7 @@ const currentProfileData = ref<any>({
   systemId: "#STANDBY#",
   idc: "R-000000000 - 000000000 - 000000000 - 00",
   additionalCode: "<<< WAITING FOR SCAN >>>",
+  sinQuality: 3, // Default SinQuality.LEVEL_3
 });
 
 const readTag = async () => {
@@ -67,6 +70,7 @@ const readTag = async () => {
               gender: parsedSinData.gender,
               metatype: parsedSinData.metatype,
               photo: parsedSinData.imageUrl || "/blank-profile-picture.svg",
+              sinQuality: parsedSinData.sinQuality || 3, // Use parsed or default
               systemId: "#ACTIVE#", // Indicate active scan
               idc: `R-${Date.now().toString().slice(-9)} - ${Math.random()
                 .toString()

--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -2,9 +2,16 @@
   <div class="id-card">
     <div class="card-header">
       <div class="header-tabs">
-        <div class="tab active"></div>
-        <div class="tab"></div>
-        <div class="tab"></div>
+        <div
+          v-for="index in effectiveSinQuality"
+          :key="`quality-tab-${index}`"
+          :class="['tab', { active: index === 1 }]"
+        >
+          <!-- Content for regular tabs, if any, or leave empty -->
+        </div>
+        <div class="tab licenses-tab">
+          Licenses
+        </div>
       </div>
     </div>
 
@@ -81,6 +88,7 @@ import {
   getFlagCSS,
   type ShadowrunNationalityType,
 } from "./shadowrun-flags";
+import { SinQuality } from "./sin-quality";
 
 interface ProfileData {
   name: string;
@@ -92,6 +100,7 @@ interface ProfileData {
   idc: string;
   additionalCode: string;
   flagColors?: string; // Optional manual override
+  sinQuality: SinQuality; // Added SIN Quality
 }
 
 interface Props {
@@ -108,7 +117,19 @@ const props = withDefaults(defineProps<Props>(), {
     systemId: "#Error1#",
     idc: "R-025648545482 - 5254267869 - 551247895512 - 02",
     additionalCode: "<<< 85478516/GTR/22145 >>> SIN ID",
+    sinQuality: SinQuality.LEVEL_1, // Default SIN quality to LEVEL_1
   }),
+});
+
+import { computed } from 'vue';
+
+const effectiveSinQuality = computed(() => {
+  const quality = props.profileData.sinQuality;
+  // Ensure quality is within the valid enum range 1-6, default to 1
+  if (quality >= SinQuality.LEVEL_1 && quality <= SinQuality.LEVEL_6) {
+    return quality;
+  }
+  return SinQuality.LEVEL_1;
 });
 
 // Function to get flag colors based on nationality or manual override
@@ -172,6 +193,17 @@ const getFlagColors = (): string => {
 
 .tab.active {
   background: rgba(255, 255, 255, 0.8);
+}
+
+.tab.licenses-tab {
+  margin-left: auto; /* Right-align the licenses tab */
+  /* Additional styling for the Licenses tab if needed */
+  font-size: 0.7em; /* Adjust font size to fit "Licenses" */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 5px; /* Add some padding */
+  white-space: nowrap; /* Prevent text wrapping */
 }
 
 .card-content {

--- a/src/components/SinForm.vue
+++ b/src/components/SinForm.vue
@@ -43,6 +43,19 @@
       </div>
 
       <div class="form-group">
+        <label for="sinQuality">SIN Quality:</label>
+        <select id="sinQuality" v-model="formData.sinQuality" required>
+          <option
+            v-for="quality in sinQualities"
+            :key="quality.value"
+            :value="quality.value"
+          >
+            {{ quality.text }}
+          </option>
+        </select>
+      </div>
+
+      <div class="form-group">
         <label for="imageUrl">Image URL:</label>
         <input type="url" id="imageUrl" v-model="formData.imageUrl" />
       </div>
@@ -68,6 +81,10 @@ import {
   getAllMetatypes,
   type ShadowrunMetatypeType,
 } from "./shadowrun-metatypes";
+import {
+  SinQuality,
+  getAllSinQualities,
+} from "./sin-quality";
 
 interface SinFormData {
   name: string;
@@ -75,10 +92,12 @@ interface SinFormData {
   nationality: ShadowrunNationalityType;
   metatype: ShadowrunMetatypeType;
   imageUrl: string;
+  sinQuality: SinQuality;
 }
 
 const nationalities = getAllNationalities();
 const metatypes = getAllMetatypes();
+const sinQualities = getAllSinQualities();
 
 const formData = reactive<SinFormData>({
   name: "",
@@ -86,6 +105,7 @@ const formData = reactive<SinFormData>({
   nationality: ShadowrunNationality.UCAS, // Default nationality
   metatype: ShadowrunMetatype.HUMAN, // Default metatype
   imageUrl: "",
+  sinQuality: SinQuality.LEVEL_3, // Default SIN quality
 });
 
 const emit = defineEmits(["submitSinData"]);

--- a/src/components/sin-quality.ts
+++ b/src/components/sin-quality.ts
@@ -1,0 +1,28 @@
+export enum SinQuality {
+  LEVEL_1 = 1,
+  LEVEL_2 = 2,
+  LEVEL_3 = 3,
+  LEVEL_4 = 4,
+  LEVEL_5 = 5,
+  LEVEL_6 = 6,
+}
+
+export const SinQualityFlairMap: ReadonlyMap<SinQuality, string> = new Map([
+  [SinQuality.LEVEL_1, "1 - Barely Exists"],
+  [SinQuality.LEVEL_2, "2 - Questionable"],
+  [SinQuality.LEVEL_3, "3 - Standard"],
+  [SinQuality.LEVEL_4, "4 - Solid"],
+  [SinQuality.LEVEL_5, "5 - High-Grade"],
+  [SinQuality.LEVEL_6, "6 - Unquestionable"],
+]);
+
+export function getSinQualityFlair(quality: SinQuality): string {
+  return SinQualityFlairMap.get(quality) || "Unknown Quality";
+}
+
+export function getAllSinQualities(): { value: SinQuality; text: string }[] {
+  return Array.from(SinQualityFlairMap.entries()).map(([value, text]) => ({
+    value,
+    text,
+  }));
+}


### PR DESCRIPTION
- Updated IdCard.vue to simplify tab generation.
- Added a computed property `effectiveSinQuality` that defaults to 1.
- Render `effectiveSinQuality` number of regular tabs, with the first being active.
- Always render a separate 'Licenses' tab, right-aligned, after the quality tabs.
- Default `sinQuality` prop in `withDefaults` is now `SinQuality.LEVEL_1`.

This makes the logic clearer and directly implements the requirement of N quality tabs plus a fixed Licenses tab.