### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -7,7 +7,8 @@ import {
   type ShadowrunNationalityType,
 } from "./components/shadowrun-flags";
 import type { ShadowrunMetatypeType } from "./components/shadowrun-metatypes"; // Import Metatype type
-import type { SinQuality } from "./components/sin-quality"; // Import SinQuality type
+// Import SinQualityValue type and SinQuality value
+import { type SinQualityValue, SinQuality } from "./components/sin-quality";
 
 // Define SINData interface
 interface SinData {
@@ -16,7 +17,7 @@ interface SinData {
   nationality: ShadowrunNationalityType;
   metatype: ShadowrunMetatypeType;
   imageUrl: string;
-  sinQuality: SinQuality; // Added SIN Quality
+  sinQuality: SinQualityValue; // Use the new SinQualityValue type
 }
 
 const message = ref("");
@@ -31,7 +32,7 @@ const currentProfileData = ref<any>({
   systemId: "#STANDBY#",
   idc: "R-000000000 - 000000000 - 000000000 - 00",
   additionalCode: "<<< WAITING FOR SCAN >>>",
-  sinQuality: 3, // Default SinQuality.LEVEL_3
+  sinQuality: SinQuality.LEVEL_3, // Default SinQuality.LEVEL_3
 });
 
 const readTag = async () => {

--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -88,7 +88,7 @@ import {
   getFlagCSS,
   type ShadowrunNationalityType,
 } from "./shadowrun-flags";
-import { SinQuality } from "./sin-quality";
+import { SinQuality, type SinQualityValue } from "./sin-quality"; // Import value and type
 
 interface ProfileData {
   name: string;
@@ -100,7 +100,7 @@ interface ProfileData {
   idc: string;
   additionalCode: string;
   flagColors?: string; // Optional manual override
-  sinQuality: SinQuality; // Added SIN Quality
+  sinQuality: SinQualityValue; // Use SinQualityValue type
 }
 
 interface Props {

--- a/src/components/SinForm.vue
+++ b/src/components/SinForm.vue
@@ -84,6 +84,7 @@ import {
 import {
   SinQuality,
   getAllSinQualities,
+  type SinQualityValue, // Import the type
 } from "./sin-quality";
 
 interface SinFormData {
@@ -92,7 +93,7 @@ interface SinFormData {
   nationality: ShadowrunNationalityType;
   metatype: ShadowrunMetatypeType;
   imageUrl: string;
-  sinQuality: SinQuality;
+  sinQuality: SinQualityValue; // Use SinQualityValue type
 }
 
 const nationalities = getAllNationalities();

--- a/src/components/sin-quality.ts
+++ b/src/components/sin-quality.ts
@@ -1,28 +1,32 @@
+// Represents the actual numeric values for SIN Quality levels
+export type SinQualityValue = 1 | 2 | 3 | 4 | 5 | 6;
+
+// Object providing named access to the SIN Quality levels
 export const SinQuality = {
-  LEVEL_1: 1,
-  LEVEL_2: 2,
-  LEVEL_3: 3,
-  LEVEL_4: 4,
-  LEVEL_5: 5,
-  LEVEL_6: 6,
+  LEVEL_1: 1 as SinQualityValue,
+  LEVEL_2: 2 as SinQualityValue,
+  LEVEL_3: 3 as SinQualityValue,
+  LEVEL_4: 4 as SinQualityValue,
+  LEVEL_5: 5 as SinQualityValue,
+  LEVEL_6: 6 as SinQualityValue,
 };
 
-export const SinQualityFlairMap: Record<SinQuality, string> = {
+export const SinQualityFlairMap = {
   [SinQuality.LEVEL_1]: "1 - Barely Exists",
   [SinQuality.LEVEL_2]: "2 - Questionable",
   [SinQuality.LEVEL_3]: "3 - Standard",
   [SinQuality.LEVEL_4]: "4 - Solid",
   [SinQuality.LEVEL_5]: "5 - High-Grade",
   [SinQuality.LEVEL_6]: "6 - Unquestionable",
-};
+} as Record<SinQualityValue, string>;
 
-export function getSinQualityFlair(quality: SinQuality): string {
+export function getSinQualityFlair(quality: SinQualityValue): string {
   return SinQualityFlairMap[quality] || "Unknown Quality";
 }
 
-export function getAllSinQualities(): { value: SinQuality; text: string }[] {
-  return Array.from(SinQualityFlairMap.entries()).map(([value, text]) => ({
-    value,
+export function getAllSinQualities(): { value: SinQualityValue; text: string }[] {
+  return Object.entries(SinQualityFlairMap).map(([valueStr, text]) => ({
+    value: Number(valueStr) as SinQualityValue,
     text,
   }));
 }


### PR DESCRIPTION
- Resolved 'vue-tsc: not found' by ensuring dependencies were installed.
- Addressed type errors related to 'SinQuality' by defining a 'SinQualityValue' type and using it consistently for type annotations, while retaining the 'SinQuality' object for runtime value access.
- Corrected issues in 'getAllSinQualities' function in 'sin-quality.ts'.
- Fixed 'SinQuality' declared but not read in 'App.vue' by using the imported value.
- Resolved type mismatch for 'SinQualityFlairMap' keys in 'sin-quality.ts'.

The project now builds successfully with 'npm run build'.