### PR TITLE
Fix: Add missing closing div for right-section in IdCard component

### DIFF
--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -85,6 +85,7 @@
             </div>
           </div>
         </div>
+      </div> <!-- Closing right-section -->
       </template>
     </div>
 


### PR DESCRIPTION
The build was failing due to a missing closing `</div>` tag for the element with class `right-section` within `src/components/IdCard.vue`. This caused a parsing error, incorrectly identifying a later element as missing its end tag.

This commit adds the required `</div>` tag, allowing the Vue template to be parsed correctly and the build to succeed.