### PR TITLE
Fix: Ensure licenses tab is clickable by adjusting z-index

### DIFF
--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -214,6 +214,8 @@ const getFlagColors = (): string => {
   height: 100%;
   width: 100%;
   align-items: center;
+  position: relative; /* Ensure it creates a stacking context */
+  z-index: 2; /* Above pseudo-elements */
 }
 
 .tab {


### PR DESCRIPTION
The licenses tab and other header tabs could become unclickable due to the `::before` and `::after` pseudo-elements on the `id-card` having a `z-index` that caused them to overlay the tabs.

This commit fixes the issue by adding `position: relative` and `z-index: 2` to the `.header-tabs` class, ensuring the tabs render above these pseudo-elements.