### PR TITLE
Feat: Implement automatic NFC scan on app load and remove manual scan…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, onMounted } from "vue";
 import IdCard from "./components/IdCard.vue";
 import SinForm from "./components/SinForm.vue";
 import {
@@ -152,6 +152,10 @@ const handleSinFormSubmit = async (sinData: SinData) => {
     message.value = `Error writing SIN data: ${error}`;
   }
 };
+
+onMounted(() => {
+  readTag();
+});
 </script>
 
 <template>
@@ -161,7 +165,6 @@ const handleSinFormSubmit = async (sinData: SinData) => {
         <IdCard :profileData="currentProfileData" />
       </div>
       <div class="nfc-controls">
-        <button type="button" @click="readTag">Read Tag</button>
         <!-- Toggle button for showing SIN Form -->
         <button type="button" @click="showSinForm = !showSinForm">
           {{ showSinForm ? "Hide SIN Form" : "Create new SIN" }}


### PR DESCRIPTION
… button

- Removed the 'Read Tag' button from App.vue.
- Added onMounted hook to App.vue to call the readTag method automatically when the component is mounted.
- This makes the application start scanning for NFC tags immediately upon opening.