### PR TITLE
Fix: Install protobuf-compiler in CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install Protobuf Compiler
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Build project
         run: npm run build
 


### PR DESCRIPTION
This commit updates the GitHub Actions workflow to install the protobuf-compiler before the build step. This resolves an error where the build process failed due to the missing 'protoc' command.