### PR TITLE
Fix: Correct Gender enum handling in SinForm dropdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "npx protoscript && vue-tsc -b && vite build",
+    "non-proto-build": "vue-tsc -b && vite build",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
- Modified SinForm.vue to use GenderJSON for populating the gender select options. This resolves a TypeScript error during the build process caused by the structure of the main Gender enum object.
- Ensured that user-friendly text is displayed for gender options while binding the correct string enum value.

Feat: Add non-proto-build script

- Added a `non-proto-build` script to package.json: `vue-tsc -b && vite build`.
- This script allows building the Vue application without running the protoscript generation step.