### PR TITLE
Fix: Ensure info modal displays correctly

### DIFF
--- a/src/composables/useReadme.ts
+++ b/src/composables/useReadme.ts
@@ -1,10 +1,11 @@
 import { ref } from "vue";
 import { marked } from "marked";
 
-export function useReadme() {
-  const showReadmeModal = ref(false);
-  const readmeHtmlContent = ref("");
+// Module-scoped reactive state (singleton)
+const showReadmeModal = ref(false);
+const readmeHtmlContent = ref("");
 
+export function useReadme() {
   const loadReadme = async () => {
     if (readmeHtmlContent.value) return; // Already loaded
 


### PR DESCRIPTION
Refactored the `useReadme` composable to use a singleton pattern for its reactive state (`showReadmeModal` and `readmeHtmlContent`).

This ensures that `App.vue` and `ReadmeInfoModal.vue` share the same state, allowing the info button in `App.vue` to correctly toggle the visibility of the `ReadmeInfoModal`.