### PR TITLE
Fix: Ensure particles render by moving background init logic

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -60,30 +60,10 @@ const handleHashChange = () => {
   }
 };
 
-const initializeBackground = () => {
-  // Add subtle mouse movement effect
-  const handleMouseMove = (e: MouseEvent) => {
-    const mouseX = e.clientX / window.innerWidth;
-    const mouseY = e.clientY / window.innerHeight;
-
-    const glow = document.querySelector(".glow-effect") as HTMLElement;
-    if (glow) {
-      glow.style.transform = `translate(-50%, -50%) translate(${mouseX * 30}px, ${mouseY * 30}px)`;
-    }
-  };
-
-  document.addEventListener("mousemove", handleMouseMove);
-
-  // Store the cleanup function
-  return () => {
-    document.removeEventListener("mousemove", handleMouseMove);
-  };
-};
-
 onMounted(() => {
   handleHashChange();
   window.addEventListener("hashchange", handleHashChange);
-  initializeBackground();
+  // initializeBackground(); // Logic moved to FancyBackground.vue
   // Initial README load can be triggered here if desired, or on first click via toggleReadmeModal
 });
 

--- a/src/components/FancyBackground.vue
+++ b/src/components/FancyBackground.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script setup lang="ts">
-import { defineProps, computed } from 'vue';
+import { defineProps, computed, onMounted, onBeforeUnmount } from 'vue';
 
 const props = defineProps<{
   count: number;
@@ -50,6 +50,41 @@ const particles = computed(() => {
 });
 
 // TODO: Move mousemove logic here if it's tightly coupled with the background
+
+let cleanupMouseMove: (() => void) | null = null;
+
+const initializeBackground = () => {
+  // Add subtle mouse movement effect
+  const handleMouseMove = (e: MouseEvent) => {
+    const mouseX = e.clientX / window.innerWidth;
+    const mouseY = e.clientY / window.innerHeight;
+
+    // Query within the component's scope if possible, or ensure it runs after DOM is ready.
+    // Since this is in FancyBackground's script setup, document.querySelector should be fine
+    // once the component is mounted.
+    const glow = document.querySelector(".glow-effect") as HTMLElement;
+    if (glow) {
+      glow.style.transform = `translate(-50%, -50%) translate(${mouseX * 30}px, ${mouseY * 30}px)`;
+    }
+  };
+
+  document.addEventListener("mousemove", handleMouseMove);
+
+  // Store the cleanup function
+  cleanupMouseMove = () => {
+    document.removeEventListener("mousemove", handleMouseMove);
+  };
+};
+
+onMounted(() => {
+  initializeBackground();
+});
+
+onBeforeUnmount(() => {
+  if (cleanupMouseMove) {
+    cleanupMouseMove();
+  }
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
I moved the background initialization logic, including the mousemove event listener for the glow effect, from App.vue into FancyBackground.vue.

This change ensures that the DOM elements within FancyBackground.vue are fully rendered before any attempts to manipulate them, which was the likely cause of the particles not appearing.

The `initializeBackground` function is now called within the `onMounted` lifecycle hook of `FancyBackground.vue`, and event listeners are cleaned up in `onBeforeUnmount`.