### PR TITLE
feat: Add colors to overlay messages

### DIFF
--- a/src/components/IdCardOverlay.vue
+++ b/src/components/IdCardOverlay.vue
@@ -1,7 +1,7 @@
 <template>
   <transition name="fade">
     <div v-if="visible" class="id-card-overlay">
-      <div class="overlay-content">
+      <div class="overlay-content" :class="resultClass">
         <p class="overlay-message">{{ message }}</p>
       </div>
     </div>
@@ -9,15 +9,24 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+import type { sincheckresult } from "../utils/sin-check-helpers";
+
 interface Props {
   message: string;
   visible: boolean;
+  resultType?: sincheckresult;
 }
 
-withDefaults(defineProps<Props>(), {
+const props = withDefaults(defineProps<Props>(), {
   message: "",
   visible: false,
+  resultType: undefined,
 });
+
+const resultClass = computed(() =>
+  props.resultType ? `result-${props.resultType}` : ""
+);
 </script>
 
 <style scoped>
@@ -48,6 +57,7 @@ withDefaults(defineProps<Props>(), {
   ); /* Darker, slightly transparent background for content */
   border-radius: 8px;
   box-shadow: 0 0 15px rgba(0, 255, 255, 0.5);
+  border: 2px solid rgba(0, 255, 255, 0.5);
 }
 
 .overlay-message {
@@ -55,6 +65,42 @@ withDefaults(defineProps<Props>(), {
   font-size: 1.5em; /* Larger font size */
   font-family: "Courier New", monospace; /* Consistent font */
   margin: 0;
+}
+
+.result-success {
+  border-color: rgba(0, 255, 0, 0.5);
+  box-shadow: 0 0 15px rgba(0, 255, 0, 0.5);
+}
+
+.result-success .overlay-message {
+  color: #00ff00;
+}
+
+.result-blip {
+  border-color: rgba(255, 255, 0, 0.5);
+  box-shadow: 0 0 15px rgba(255, 255, 0, 0.5);
+}
+
+.result-blip .overlay-message {
+  color: #ffff00;
+}
+
+.result-flagged {
+  border-color: rgba(255, 105, 180, 0.5);
+  box-shadow: 0 0 15px rgba(255, 105, 180, 0.5);
+}
+
+.result-flagged .overlay-message {
+  color: #ff69b4;
+}
+
+.result-burned {
+  border-color: rgba(255, 0, 0, 0.5);
+  box-shadow: 0 0 15px rgba(255, 0, 0, 0.5);
+}
+
+.result-burned .overlay-message {
+  color: #ff0000;
 }
 
 /* Fade transition */


### PR DESCRIPTION
Implement a way to send colors along with the message to idcardoverlay from idcard.vue. Then along with the verification messages send some colors that fit the rest of the application these colors should define the border color of the message box as well as the text color.