### PR TITLE
feat: Implement Read and Write Tag buttons in App.vue

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@ const { toggleReadmeModal } = useReadme();
 const { abortScan } = useNfc(); // Import abortScan from useNfc
 
 const idCardRef = ref<InstanceType<typeof IdCard> | null>(null);
+const sinFormRef = ref<InstanceType<typeof SinForm> | null>(null);
 const selectedScanLevel = ref<SinQualityType>(SinQuality.SIN_QUALITY_LEVEL_3);
 const showScanLevelDropdown = ref(false);
 const showSettingsOverlay = ref(false);
@@ -155,16 +156,19 @@ onBeforeUnmount(() => {
         Create your SIN
       </div>
       <div class="sin-form-section">
-        <SinForm />
+        <SinForm ref="sinFormRef" />
       </div>
       <div class="navigation-buttons">
-        <div @click="" class="navigation-button">
+        <div @click="sinFormRef?.readTag(false)" class="navigation-button">
           <div class="glitch-text" data-text="Read Tag">Read Tag</div>
         </div>
         <div @click="setView('landing')" class="navigation-button">
           <div class="glitch-text" data-text="🏚️">🏚️</div>
         </div>
-        <div @click="" class="navigation-button">
+        <div
+          @click="sinFormRef?.writeTag(sinFormRef.formData)"
+          class="navigation-button"
+        >
           <div class="glitch-text" data-text="Write Tag">Write Tag</div>
         </div>
       </div>

--- a/src/components/SinForm.vue
+++ b/src/components/SinForm.vue
@@ -459,6 +459,12 @@ const submitForm = () => {
   }
   writeTag(formData);
 };
+
+defineExpose({
+  readTag,
+  writeTag,
+  formData,
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
- Expose `readTag`, `writeTag`, and `formData` from `SinForm.vue`.
- Add a ref to `SinForm` in `App.vue` to access the exposed functions and data.
- Implement the `click` handlers for the "Read Tag" and "Write Tag" buttons in `App.vue` to call the corresponding functions from `SinForm.vue`.