### PR TITLE
feat(idcard): Rework left-content to use grid layout

### DIFF
--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -841,7 +841,13 @@ defineExpose({
   height: 100%;
 }
 
-.left-content,
+.left-content {
+  display: grid;
+  grid-template-columns: max-content max-content 1fr;
+  gap: 5px;
+  align-items: center;
+}
+
 .right-content {
   display: flex;
   flex-direction: column;
@@ -854,11 +860,7 @@ defineExpose({
 }
 
 .detail-row {
-  display: flex;
-  flex-direction: row;
-  justify-content: start;
-  font-size: clamp(0.6em, 2svh, 1em); /* Responsive font size */
-  gap: 1%;
+  display: contents; /* This makes the detail-row a direct child of the grid */
 }
 
 .label {


### PR DESCRIPTION
Reworks the left-content section in the IdCard.vue component to use a CSS grid layout. This ensures that all label texts line up perfectly, with the ':' column aligning with the widest label, while preserving the right-content div.