### PR TITLE
feat: Add validateLicense method and text map

### DIFF
--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -368,6 +368,7 @@ import {
 import { SinQualityFlairMap, SinQualityTitleMap } from "../utils/sin-quality";
 import { checkSin } from "../utils/sin-check-helpers";
 import { sinScanResultTextMap } from "../utils/sin-scan-result";
+import { licenseScanResultTextMap } from "../utils/license-scan-result";
 import { useNfc } from "../composables/useNfc";
 import type { sincheckresult } from "../utils/sin-check-helpers";
 
@@ -510,8 +511,22 @@ const performSinCheck = (quality: SinQuality) => {
   }, 2000);
 };
 
+const validateLicense = (quality: SinQuality) => {
+  const result = checkSin(
+    SinQuality._toInt(quality),
+    SinQuality._toInt(props.scanLevel)
+  );
+  clearTimeout(overlayTimeout);
+  overlayMessage.value = licenseScanResultTextMap[result];
+  overlayResultType.value = result;
+  isOverlayVisible.value = true;
+  overlayTimeout = setTimeout(() => {
+    isOverlayVisible.value = false;
+  }, 2000);
+};
+
 const performLicenseCheck = (quality: SinQuality) => {
-  performSinCheck(quality);
+  validateLicense(quality);
 };
 
 defineExpose({

--- a/src/utils/license-scan-result.ts
+++ b/src/utils/license-scan-result.ts
@@ -1,0 +1,8 @@
+import type { sincheckresult } from "./sin-check-helpers";
+
+export const licenseScanResultTextMap: Record<sincheckresult, string> = {
+  success: "Verification successful. License is valid.",
+  blip: "Verification blip. License may be forged or duplicated.",
+  flagged: "Verification annomoly. License is likely forged or has alerts.",
+  burned: "Verification failed. License is invalid and has been blacklisted.",
+};


### PR DESCRIPTION
Introduces a `validateLicense` method to `idcard.vue` with its own text map, duplicating the SIN validation text map but with 'license' instead of 'SIN'.