### PR TITLE
I've updated the idcard component to use the correct message for the …

### DIFF
--- a/src/components/IdCard.vue
+++ b/src/components/IdCard.vue
@@ -433,7 +433,7 @@ watch(
         performSinCheck(internalProfileData.value.sinQuality);
       } else {
         clearTimeout(overlayTimeout);
-        overlayMessage.value = "SIN Scanned successfully";
+        overlayMessage.value = newMessage || "SIN Scanned successfully";
         overlayResultType.value = "success";
         isOverlayVisible.value = true;
         overlayTimeout = setTimeout(() => {


### PR DESCRIPTION
…SIN scan success overlay. Previously, it was using a hardcoded message. Now, it will use the message provided by the `useNfc` composable, ensuring that the correct, dynamic message is displayed to you.